### PR TITLE
Add custom number_format function

### DIFF
--- a/structr-ui/src/main/java/org/structr/web/entity/dom/DOMNode.java
+++ b/structr-ui/src/main/java/org/structr/web/entity/dom/DOMNode.java
@@ -18,6 +18,8 @@
  */
 package org.structr.web.entity.dom;
 
+import java.text.NumberFormat;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -26,6 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -407,6 +410,38 @@ public abstract class DOMNode extends LinkedTreeNode implements Node, Renderable
 			}
 
 		});
+	        functions.put("number_format", new Function<String, String>() {
+	
+	            @Override
+	            public String apply(String[] s) {
+	
+	                String result = "";
+	                    String errorMsg = "<strong>ERROR! Usage: ${number_format(value, ISO639LangCode, pattern)}. ex:${number_format(12345.6789, 'en', '#,##0.00')} For more infos about patterns <a href='http://docs.oracle.com/javase/6/docs/api/java/text/DecimalFormat.html'>refer to the documentation</a><strong>";
+	
+	                if (s != null && s.length == 3) {
+	
+	                    try {
+	
+	                        Double val = Double.parseDouble(s[0]);
+	                        String langCode = s[1];
+	                        String pattern = s[2];
+	
+	                        NumberFormat formatter = DecimalFormat.getInstance(new Locale(langCode));
+	                        ((DecimalFormat) formatter).applyLocalizedPattern(pattern);
+	                        result = formatter.format(val);
+	
+	                    } catch (Throwable t) {
+	                        result = errorMsg;
+	                    }
+	
+	                } else {
+	                    result = errorMsg;
+	                }
+	
+	                return result;
+	            }
+	
+	        });
 		functions.put("not", new Function<String, String>() {
 
 			@Override


### PR DESCRIPTION
number_format takes three parameters (value, ISO639LangCode, pattern) and formats the value accordingly.
It is used like this: ${number_format(12345.6789, 'en', '#,##0.00')}

Discussion:
1. defaults: I purposely did not include default values for langCode and pattern so that the user has to think about these values and has to set them manually - adding defaults is obviously up to you.
2. error case: I decided to output a quite long error message in case of an error. This may or may not clash with your style standards. I wanted to keep my changes in one spot (except for the imports, obviously) so that it is easier to see what happens.
