### PR TITLE
Fixed bug where custom onDelete actions could not be created.

### DIFF
--- a/structr-core/src/main/java/org/structr/schema/SchemaHelper.java
+++ b/structr-core/src/main/java/org/structr/schema/SchemaHelper.java
@@ -726,10 +726,14 @@ public class SchemaHelper {
 		src.append("\n\t@Override\n");
 		src.append("\tpublic boolean ");
 		src.append(type.getMethod());
-		src.append("(SecurityContext securityContext, ErrorBuffer errorBuffer) throws FrameworkException {\n\n");
+		src.append("(");
+      src.append(type.getSignature());
+      src.append(") throws FrameworkException {\n\n");
 		src.append("\t\tboolean error = !super.");
 		src.append(type.getMethod());
-		src.append("(securityContext, errorBuffer);\n\n");
+		src.append("(");
+      src.append(type.getParameters());
+      src.append(");\n\n");
 
 		if (!actionList.isEmpty()) {
 

--- a/structr-core/src/main/java/org/structr/schema/action/Actions.java
+++ b/structr-core/src/main/java/org/structr/schema/action/Actions.java
@@ -12,16 +12,31 @@ public class Actions {
 
 	public enum Type {
 
-		Create("onCreation"), Save("onModification"), Delete("onDeletion"), Custom("");
+		Create("onCreation","SecurityContext securityContext, ErrorBuffer errorBuffer", "securityContext, errorBuffer"), 
+      Save("onModification","SecurityContext securityContext, ErrorBuffer errorBuffer", "securityContext, errorBuffer"), 
+      Delete("onDeletion","SecurityContext securityContext, ErrorBuffer errorBuffer, PropertyMap properties", "securityContext, errorBuffer, properties"), 
+      Custom("", "", "");
 
-		Type(final String method) {
+		Type(final String method, final String signature, final String parameters) {
 			this.method = method;
+			this.signature = signature;
+			this.parameters = parameters;
 		}
 
 		private String method = null;
+		private String signature = null;
+		private String parameters = null;
 
 		public String getMethod() {
 			return method;
+		}
+
+		public String getSignature() {
+			return signature;
+		}
+
+		public String getParameters() {
+			return parameters;
 		}
 	}
 


### PR DESCRIPTION
The onDelete function has a different function signature which wasn't handled correctly by the code generator in SchemaHelper.
