### PR TITLE
make the HTML output of the REST servlet JSON-compatible.

### DIFF
--- a/structr-rest/src/main/java/org/structr/rest/serialization/html/Tag.java
+++ b/structr-rest/src/main/java/org/structr/rest/serialization/html/Tag.java
@@ -127,6 +127,14 @@ public abstract class Tag {
 		return parent;
 	}
 
+	public void appendComma () {
+		if (this.children.size() > 0) {
+			((LinkedList<Tag>)getChildren()).getLast().appendComma();
+		} else if (this.text != null) {
+			this.text = this.text.concat(",");
+		}
+	}
+
 	// ----- protected methods -----
 	protected void render(final PrintWriter writer, final int level) throws IOException {
 		


### PR DESCRIPTION
Some notes on my changes:
- I noticed that arrays were missing the opening and closing brackets so I added those
- it would have been easier to make the changes in pure CSS (see below) but then the characters can not be copied (really bad if you want a quick and dirty solution for getting a JSON object)
- since every tag can only contain one text string and multiple other tags, I was not able to separate the quotation marks from the links (for id fields)
- I removed a bit of copy which was used to output some info about an object. Mainly to make it JSON-compatible (and because all that info should be inside the object itself)
- I intentionally did not remove the reference to the (broken) Javascript file
- I also did not touch the CSS. Personally I would inline this so the page does not make requests to structr.org (but thats personal preference I guess)
# CSS Solution

```
/* insert a "," after every li */
li:after {
  content: ",";
}

/* remove the "," for the the last child of the li */
li:last-child:after {
  content: "";
}


.string:before {
  content: '"';
}
.string:after {
  content: '"';
}

a.id:before {
  content: '"';
}
a.id:after {
  content: '"';
}
```
