### PR TITLE
make the HTML output of the REST servlet JSON-compatible - part 2

### DIFF
--- a/structr-rest/src/main/java/org/structr/rest/serialization/StructrJsonHtmlWriter.java
+++ b/structr-rest/src/main/java/org/structr/rest/serialization/StructrJsonHtmlWriter.java
@@ -37,8 +37,6 @@ import org.structr.rest.serialization.html.attr.Css;
 import org.structr.rest.serialization.html.attr.Href;
 import org.structr.rest.serialization.html.attr.If;
 import org.structr.rest.serialization.html.attr.Onload;
-import org.structr.rest.serialization.html.attr.Rel;
-import org.structr.rest.serialization.html.attr.Src;
 import org.structr.rest.serialization.html.attr.Type;
 
 /**
@@ -238,6 +236,9 @@ public class StructrJsonHtmlWriter implements RestWriter {
 			currentElement.inline("a").css("id").attr(new Href(restPath + "/" + value)).text("\"", value, "\"");
 
 		} else {
+
+			value = value.replaceAll("\\\\", "\\\\\\\\");           // escape backslashes in strings
+			value = value.replaceAll("\"", "\\\\\\\"");             // escape quotation marks inside strings
 
 			currentElement.inline("span").css("string").text("\"", value, "\"");
 


### PR DESCRIPTION
Small enhancement for https://github.com/structr/structr/pull/292

In that PR I forgot that strings can contain backslashes and quotation marks - both have to be escaped so that the output is proper JSON
