### PR TITLE
Fix guard against modifying system properties.

### DIFF
--- a/structr-core/src/main/java/org/structr/core/property/AbstractPrimitiveProperty.java
+++ b/structr-core/src/main/java/org/structr/core/property/AbstractPrimitiveProperty.java
@@ -43,7 +43,6 @@ public abstract class AbstractPrimitiveProperty<T> extends Property<T> {
 
 	private static final Logger logger = Logger.getLogger(AbstractPrimitiveProperty.class.getName());
 
-	private boolean internalSystemProperty = false;
 	protected GraphObject entity;
 	protected SecurityContext securityContext;
 
@@ -180,7 +179,7 @@ public abstract class AbstractPrimitiveProperty<T> extends Property<T> {
 
 				} else {
 
-					if (!internalSystemProperty || internalSystemPropertiesUnlocked) {
+					if (!isSystemInternal() || internalSystemPropertiesUnlocked) {
 
 						propertyContainer.setProperty(dbName(), convertedValue);
 


### PR DESCRIPTION
Current version bypasses `org.structr.core.property.Property#systemInternal` and doesn't prevent write access to internal properties.

`AbstractNode` and `AbstractRelationship` [both](https://github.com/structr/structr/blob/master/structr-core/src/main/java/org/structr/core/entity/AbstractNode.java#L1429) [override](https://github.com/structr/structr/blob/master/structr-core/src/main/java/org/structr/core/entity/AbstractRelationship.java#L587) the `setProperty` method, but throw a FrameworkException with an HTTP code 422, whereas this method just logs a warning. For consistency (and testability) throwing an exception here might be a good idea.

I hereby agree to submit these and future contributions under the terms of the [Structr CLA](https://structr.org/cla).
