### PR TITLE
Update Dockerfile to the most recent version

### DIFF
--- a/structr-ui/docker/Dockerfile
+++ b/structr-ui/docker/Dockerfile
@@ -4,13 +4,13 @@
 #
 # Start with:
 #
-# sudo docker run --name="structr-1.1-SNAPSHOT" -p 0.0.0.0:7474:7474 -p 0.0.0.0:8082:8082 -p 0.0.0.0:8021:8021 -t -i structr/structr:1.1-SNAPSHOT
+# sudo docker run --name="structr-2.0.1" -p 0.0.0.0:7474:7474 -p 0.0.0.0:8082:8082 -p 0.0.0.0:8021:8021 -t -i structr/structr:2.0.1
 
 FROM ubuntu:latest
 MAINTAINER Axel Morgner <axel@morgner.de>
 
-# Install wget and Java 7 (OpenJDK)
-RUN	apt-get update && apt-get -y install wget openjdk-7-jdk
+# Install wget and Java 8 (OpenJDK)
+RUN	apt-get update && apt-get -y install wget openjdk-8-jdk
 #RUN echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
 #RUN echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
 #RUN apt-get update
@@ -20,13 +20,16 @@ RUN	apt-get update && apt-get -y install wget openjdk-7-jdk
 #RUN apt-get -y install wget oracle-java7-installer
 
 # Download Structr
-RUN wget "http://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=org.structr&a=structr-ui&v=1.1-SNAPSHOT&e=deb" --content-disposition
+RUN wget -q "https://search.maven.org/remotecontent?filepath=org/structr/structr-ui/2.0.1/structr-ui-2.0.1.deb" --content-disposition
 
 # Install Structr Debian package
-RUN	dpkg -i structr-ui-1.1-*.deb
+RUN	dpkg -i structr-ui-*.deb
 
 # Expose ports 7474 (Neo4j http), 8082 (Structr http) and 8021 (Structr ftp) from the container to the host (run container with -P to expose all ports to the host)
 EXPOSE 7474 8021 8082
 
+# Entry points for data storage
+VOLUME /usr/lib/structr-ui/db /usr/lib/structr-ui/files
+
 # Set start command
-CMD cd /usr/lib/structr-ui && if [ ! -e "logs" ]; then mkdir logs; fi && if [ ! -e "structr" ]; then jar -xf structr-*.jar structr ; fi && if [ ! -f "structr.conf" ] ; then cat structr.conf_templ | sed 's/src\/main\/resources\///' > structr.conf ; fi && java -cp lib/*:structr-ui.jar -server -d64 -Xms1g -Xmx1g -XX:+UseG1GC -XX:MaxPermSize=128m -XX:+UseNUMA org.structr.Server > /var/log/structr-ui.log
+CMD cd /usr/lib/structr-ui && if [ ! -e "logs" ]; then mkdir logs; fi && if [ ! -e "structr" ]; then jar -xf structr-*.jar structr ; fi && if [ ! -f "structr.conf" ] ; then cat structr.conf_templ | sed 's/src\/main\/resources\///' > structr.conf ; fi && java -cp lib/*:structr-ui-2.0.1.jar -server -d64 -Xms1g -Xmx1g -XX:+UseG1GC -XX:MaxPermSize=128m -XX:+UseNUMA org.structr.Server > /var/log/structr-ui.log


### PR DESCRIPTION
Hi,
I agree to the CLA ( https://structr.org/cla ).
~
This upgrades the Dockerfile for structr 2.0.1 and Java 8.
I've also included VOLUME lines to keep data on separate mounts.
Maybe this saves others a little time.

Cheers
