### PR TITLE
"find_privileged()" method to query entities in a superuser context.

### DIFF
--- a/structr-core/src/main/java/org/structr/core/function/Functions.java
+++ b/structr-core/src/main/java/org/structr/core/function/Functions.java
@@ -40,6 +40,7 @@ import org.structr.core.parser.IfExpression;
 import org.structr.core.parser.NullExpression;
 import org.structr.core.parser.RootExpression;
 import org.structr.core.parser.ValueExpression;
+import org.structr.core.parser.function.PrivilegedFindFunction;
 import org.structr.schema.action.ActionContext;
 import org.structr.schema.action.Function;
 
@@ -319,6 +320,7 @@ public class Functions {
 		functions.put("changelog", new ChangelogFunction());
 		functions.put("timer", new TimerFunction());
 		functions.put("str_replace", new StrReplaceFunction());
+                functions.put("privileged_find", new PrivilegedFindFunction());
 
 		// ----- BEGIN functions with side effects -----
 		functions.put("retrieve", new RetrieveFunction());

--- a/structr-core/src/main/java/org/structr/core/function/Functions.java
+++ b/structr-core/src/main/java/org/structr/core/function/Functions.java
@@ -320,7 +320,7 @@ public class Functions {
 		functions.put("changelog", new ChangelogFunction());
 		functions.put("timer", new TimerFunction());
 		functions.put("str_replace", new StrReplaceFunction());
-                functions.put("privileged_find", new PrivilegedFindFunction());
+                functions.put("find_privileged", new PrivilegedFindFunction());
 
 		// ----- BEGIN functions with side effects -----
 		functions.put("retrieve", new RetrieveFunction());

--- a/structr-core/src/main/java/org/structr/core/parser/function/PrivilegedFindFunction.java
+++ b/structr-core/src/main/java/org/structr/core/parser/function/PrivilegedFindFunction.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2010-2016 Structr GmbH
+ *
+ * This file is part of Structr <http://structr.org>.
+ *
+ * Structr is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Structr is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Structr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.structr.core.parser.function;
+
+import java.util.Map;
+import java.util.logging.Level;
+import org.structr.common.SecurityContext;
+import org.structr.common.error.FrameworkException;
+import org.structr.core.GraphObject;
+import org.structr.core.app.Query;
+import org.structr.core.app.StructrApp;
+import org.structr.core.converter.PropertyConverter;
+import org.structr.core.property.PropertyKey;
+import org.structr.core.property.PropertyMap;
+import org.structr.schema.ConfigurationProvider;
+import org.structr.schema.action.ActionContext;
+import org.structr.schema.action.Function;
+
+public class PrivilegedFindFunction extends Function<Object, Object> {
+
+    public static final String ERROR_MESSAGE_PRIVILEGEDFIND = "Usage: ${privileged_find(type, key, value)}. Example: ${privileged_find(\"User\", \"email\", \"tester@test.com\"}";
+
+    @Override
+    public Object apply(ActionContext ctx, GraphObject entity, Object[] sources) throws FrameworkException {
+
+		if (sources != null) {
+
+			final SecurityContext securityContext = SecurityContext.getSuperUserInstance();
+			final ConfigurationProvider config = StructrApp.getConfiguration();
+			final Query query = StructrApp.getInstance(securityContext).nodeQuery().sort(GraphObject.createdDate).order(false);
+
+			// the type to query for
+			Class type = null;
+
+			if (sources.length >= 1 && sources[0] != null) {
+
+				final String typeString = sources[0].toString();
+				type = config.getNodeEntityClass(typeString);
+
+				if (type != null) {
+
+					query.andTypes(type);
+
+				} else {
+
+					logger.log(Level.WARNING, "Error in privileged_find(): type \"{0}\" not found.", typeString);
+					return "Error in privileged_find(): type " + typeString + " not found.";
+
+				}
+			}
+
+			// exit gracefully instead of crashing..
+			if (type == null) {
+				logger.log(Level.WARNING, "Error in privileged_find(): no type specified. Parameters: {0}", getParametersAsString(sources));
+				return "Error in privileged_find(): no type specified.";
+			}
+
+			// experimental: disable result count, prevents instantiation
+			// of large collections just for counting all the objects..
+			securityContext.ignoreResultCount(true);
+
+			// extension for native javascript objects
+			if (sources.length == 2 && sources[1] instanceof Map) {
+
+				query.and(PropertyMap.inputTypeToJavaType(securityContext, type, (Map)sources[1]));
+
+			} else if (sources.length == 2) {
+
+				if (sources[1] == null) {
+
+					throw new IllegalArgumentException();
+				}
+
+				// special case: second parameter is a UUID
+				final PropertyKey key = config.getPropertyKeyForJSONName(type, "id");
+
+				query.and(key, sources[1].toString());
+
+				final int resultCount = query.getResult().size();
+
+				switch (resultCount) {
+					case 1:
+						return query.getFirst();
+					case 0:
+						return null;
+					default:
+						throw new FrameworkException(400, "Multiple Objects found for id! [" + sources[1].toString() + "]");
+				}
+
+			} else {
+
+				final Integer parameter_count = sources.length;
+
+				if (parameter_count % 2 == 0) {
+
+					throw new FrameworkException(400, "Invalid number of parameters: " + parameter_count + ". Should be uneven: " + ERROR_MESSAGE_PRIVILEGEDFIND);
+				}
+
+				for (Integer c = 1; c < parameter_count; c += 2) {
+
+					final PropertyKey key = config.getPropertyKeyForJSONName(type, sources[c].toString());
+
+					if (key != null) {
+
+						// throw exception if key is not indexed (otherwise the user will never know)
+						if (!key.isSearchable()) {
+
+							throw new FrameworkException(400, "Search key " + key.jsonName() + " is not indexed.");
+						}
+
+						final PropertyConverter inputConverter = key.inputConverter(securityContext);
+						Object value = sources[c + 1];
+
+						if (inputConverter != null) {
+
+							value = inputConverter.convert(value);
+						}
+
+						query.and(key, value);
+					}
+				}
+			}
+
+			return query.getAsList();
+		}
+
+		return "";
+    }
+
+    @Override
+    public String usage(boolean inJavaScriptContext) {
+        return ERROR_MESSAGE_PRIVILEGEDFIND;
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Returns a collection of entities of the given type from the database, takes optional key/value pairs. Executed in a super user context.";
+    }
+
+    @Override
+    public String getName() {
+        return("privileged_find()");
+    }
+
+}

--- a/structr-core/src/main/java/org/structr/core/parser/function/PrivilegedFindFunction.java
+++ b/structr-core/src/main/java/org/structr/core/parser/function/PrivilegedFindFunction.java
@@ -34,7 +34,7 @@ import org.structr.schema.action.Function;
 
 public class PrivilegedFindFunction extends Function<Object, Object> {
 
-    public static final String ERROR_MESSAGE_PRIVILEGEDFIND = "Usage: ${privileged_find(type, key, value)}. Example: ${privileged_find(\"User\", \"email\", \"tester@test.com\"}";
+    public static final String ERROR_MESSAGE_PRIVILEGEDFIND = "Usage: ${find_privileged(type, key, value)}. Example: ${find_privileged(\"User\", \"email\", \"tester@test.com\"}";
 
     @Override
     public Object apply(ActionContext ctx, GraphObject entity, Object[] sources) throws FrameworkException {
@@ -59,16 +59,16 @@ public class PrivilegedFindFunction extends Function<Object, Object> {
 
 				} else {
 
-					logger.log(Level.WARNING, "Error in privileged_find(): type \"{0}\" not found.", typeString);
-					return "Error in privileged_find(): type " + typeString + " not found.";
+					logger.log(Level.WARNING, "Error in find_privileged(): type \"{0}\" not found.", typeString);
+					return "Error in find_privileged(): type " + typeString + " not found.";
 
 				}
 			}
 
 			// exit gracefully instead of crashing..
 			if (type == null) {
-				logger.log(Level.WARNING, "Error in privileged_find(): no type specified. Parameters: {0}", getParametersAsString(sources));
-				return "Error in privileged_find(): no type specified.";
+				logger.log(Level.WARNING, "Error in find_privileged(): no type specified. Parameters: {0}", getParametersAsString(sources));
+				return "Error in find_privileged(): no type specified.";
 			}
 
 			// experimental: disable result count, prevents instantiation
@@ -155,7 +155,7 @@ public class PrivilegedFindFunction extends Function<Object, Object> {
 
     @Override
     public String getName() {
-        return("privileged_find()");
+        return("find_privileged()");
     }
 
 }

--- a/structr-core/src/test/java/org/structr/schema/action/ActionContextTest.java
+++ b/structr-core/src/test/java/org/structr/schema/action/ActionContextTest.java
@@ -1363,11 +1363,11 @@ public class ActionContextTest extends StructrTest {
 
 		try (final Tx tx = app.tx()) {
 
-                        assertEquals("JavaScript: Trying to find entity with type,key,value!", "InitialString", Scripting.replaceVariables(ctx, testNode, "${{ var t1 = Structr.first(Structr.privileged_find('TestOne','anInt','42')); Structr.print(t1.aString); }}"));
+                        assertEquals("JavaScript: Trying to find entity with type,key,value!", "InitialString", Scripting.replaceVariables(ctx, testNode, "${{ var t1 = Structr.first(Structr.find_privileged('TestOne','anInt','42')); Structr.print(t1.aString); }}"));
 
-                        assertEquals("JavaScript: Trying to find entity with type,id!", "InitialString", Scripting.replaceVariables(ctx, testNode, "${{ var t1 = Structr.privileged_find('TestOne','"+uuid+"'); Structr.print(t1.aString); }}"));
+                        assertEquals("JavaScript: Trying to find entity with type,id!", "InitialString", Scripting.replaceVariables(ctx, testNode, "${{ var t1 = Structr.find_privileged('TestOne','"+uuid+"'); Structr.print(t1.aString); }}"));
 
-                        assertEquals("JavaScript: Trying to find entity with type,key,value,key,value!", "InitialString", Scripting.replaceVariables(ctx, testNode, "${{ var t1 = Structr.first(Structr.privileged_find('TestOne','anInt','42','aString','InitialString')); Structr.print(t1.aString); }}"));
+                        assertEquals("JavaScript: Trying to find entity with type,key,value,key,value!", "InitialString", Scripting.replaceVariables(ctx, testNode, "${{ var t1 = Structr.first(Structr.find_privileged('TestOne','anInt','42','aString','InitialString')); Structr.print(t1.aString); }}"));
 
 			tx.success();
 

--- a/structr-core/src/test/java/org/structr/schema/action/ActionContextTest.java
+++ b/structr-core/src/test/java/org/structr/schema/action/ActionContextTest.java
@@ -48,6 +48,7 @@ import org.structr.core.function.DateFormatFunction;
 import org.structr.core.function.FindFunction;
 import org.structr.core.function.NumberFormatFunction;
 import org.structr.core.function.RoundFunction;
+import org.structr.core.property.StringProperty;
 import org.structr.core.script.Scripting;
 
 /**
@@ -1145,7 +1146,7 @@ public class ActionContextTest extends StructrTest {
 			assertEquals("Invalid find() result", FindFunction.ERROR_MESSAGE_FIND_NO_TYPE_SPECIFIED, Scripting.replaceVariables(ctx, testOne, "${find(this.alwaysNull)}"));
 			assertEquals("Invalid find() result", FindFunction.ERROR_MESSAGE_FIND_NO_TYPE_SPECIFIED, Scripting.replaceVariables(ctx, testOne, "${find(this.alwaysNull, this.alwaysNull)}"));
 			assertEquals("Invalid find() result", FindFunction.ERROR_MESSAGE_FIND_TYPE_NOT_FOUND + "NonExistingType", Scripting.replaceVariables(ctx, testOne, "${find('NonExistingType')}"));
-			
+
 			// search
 			assertEquals("Invalid search() result", testOne.getUuid(), Scripting.replaceVariables(ctx, testTwo, "${first(search('TestOne', 'name', 'A-nice-little-name-for-my-test-object'))}"));
 			assertEquals("Invalid search() result", testOne.getUuid(), Scripting.replaceVariables(ctx, testTwo, "${first(search('TestOne', 'name', '*little-name-for-my-test-object'))}"));
@@ -1334,6 +1335,49 @@ public class ActionContextTest extends StructrTest {
 			fail("Unexpected exception");
 
 		}
+	}
+
+
+	public void testPrivilegedFind () {
+
+		final ActionContext ctx = new ActionContext(securityContext, null);
+
+		TestOne testNode = null;
+                String uuid ="";
+
+		try (final Tx tx = app.tx()) {
+
+			testNode = createTestNode(TestOne.class);
+			testNode.setProperty(TestOne.aString, "InitialString");
+			testNode.setProperty(TestOne.anInt, 42);
+                        uuid = testNode.getProperty(new StringProperty("id"));
+
+			tx.success();
+
+		} catch (FrameworkException ex) {
+
+			logger.log(Level.WARNING, "", ex);
+			fail("Unexpected exception");
+
+		}
+
+		try (final Tx tx = app.tx()) {
+
+                        assertEquals("JavaScript: Trying to find entity with type,key,value!", "InitialString", Scripting.replaceVariables(ctx, testNode, "${{ var t1 = Structr.first(Structr.privileged_find('TestOne','anInt','42')); Structr.print(t1.aString); }}"));
+
+                        assertEquals("JavaScript: Trying to find entity with type,id!", "InitialString", Scripting.replaceVariables(ctx, testNode, "${{ var t1 = Structr.privileged_find('TestOne','"+uuid+"'); Structr.print(t1.aString); }}"));
+
+                        assertEquals("JavaScript: Trying to find entity with type,key,value,key,value!", "InitialString", Scripting.replaceVariables(ctx, testNode, "${{ var t1 = Structr.first(Structr.privileged_find('TestOne','anInt','42','aString','InitialString')); Structr.print(t1.aString); }}"));
+
+			tx.success();
+
+		} catch (FrameworkException ex) {
+
+                        logger.log(Level.WARNING, "", ex);
+                        fail("Unexpected exception");
+
+                }
+
 	}
 
 }


### PR DESCRIPTION
Added new "privileged_find()" method to query entities in a superuser context. This can be used to allow anonymous users access to certain data. A test case is included in this commit as well.