### PR TITLE
Bugfix: Enforce necessary naming conventions for properties, methods,…

### DIFF
--- a/structr-core/src/main/java/org/structr/core/entity/SchemaMethod.java
+++ b/structr-core/src/main/java/org/structr/core/entity/SchemaMethod.java
@@ -21,8 +21,8 @@ package org.structr.core.entity;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
-import java.lang.reflect.TypeVariable;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -34,13 +34,16 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.structr.api.util.Iterables;
 import org.structr.common.PropertyView;
+import org.structr.common.ValidationHelper;
 import org.structr.common.View;
+import org.structr.common.error.ErrorBuffer;
 import org.structr.common.error.FrameworkException;
 import org.structr.core.app.App;
 import org.structr.core.app.StructrApp;
 import org.structr.core.entity.relationship.SchemaMethodParameters;
 import org.structr.core.entity.relationship.SchemaNodeMethod;
 import org.structr.core.graph.ModificationQueue;
+import static org.structr.core.graph.NodeInterface.name;
 import org.structr.core.notion.PropertySetNotion;
 import org.structr.core.property.ArrayProperty;
 import org.structr.core.property.BooleanProperty;
@@ -57,6 +60,8 @@ import org.structr.schema.action.ActionEntry;
  *
  */
 public class SchemaMethod extends SchemaReloadingNode implements Favoritable {
+
+	public static final String schemaMethodNamePattern    = "[a-zA-Z_][a-zA-Z0-9_]*";
 
 	public static final Property<Iterable<SchemaMethodParameter>> parameters = new EndNodes<>("parameters", SchemaMethodParameters.class);
 	public static final Property<AbstractSchemaNode> schemaNode              = new StartNode<>("schemaNode", SchemaNodeMethod.class, new PropertySetNotion(AbstractNode.id, AbstractNode.name, SchemaNode.isBuiltinType));
@@ -132,6 +137,16 @@ public class SchemaMethod extends SchemaReloadingNode implements Favoritable {
 
 	public boolean isJava() {
 		return "java".equals(getProperty(codeType));
+	}
+
+	@Override
+	public boolean isValid(final ErrorBuffer errorBuffer) {
+
+		boolean valid = super.isValid(errorBuffer);
+
+		valid &= ValidationHelper.isValidStringMatchingRegex(this, name, schemaMethodNamePattern, errorBuffer);
+
+		return valid;
 	}
 
 	@Override

--- a/structr-core/src/main/java/org/structr/core/entity/SchemaProperty.java
+++ b/structr-core/src/main/java/org/structr/core/entity/SchemaProperty.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.structr.api.util.Iterables;
 import org.structr.common.PropertyView;
 import org.structr.common.SecurityContext;
+import org.structr.common.ValidationHelper;
 import org.structr.common.View;
 import org.structr.common.error.ErrorBuffer;
 import org.structr.common.error.FrameworkException;
@@ -43,6 +44,7 @@ import static org.structr.core.entity.SchemaNode.GraphQLNodeReferenceName;
 import org.structr.core.entity.relationship.SchemaNodeProperty;
 import org.structr.core.entity.relationship.SchemaViewProperty;
 import org.structr.core.graph.ModificationQueue;
+import static org.structr.core.graph.NodeInterface.name;
 import org.structr.core.notion.PropertySetNotion;
 import org.structr.core.property.ArrayProperty;
 import org.structr.core.property.BooleanProperty;
@@ -69,6 +71,8 @@ import org.structr.schema.parser.PropertyDefinition;
  *
  */
 public class SchemaProperty extends SchemaReloadingNode implements PropertyDefinition {
+
+	public static final String schemaPropertyNamePattern    = "[a-zA-Z_][a-zA-Z0-9_]*";
 
 	private static final Logger logger = LoggerFactory.getLogger(SchemaProperty.class.getName());
 
@@ -682,6 +686,16 @@ public class SchemaProperty extends SchemaReloadingNode implements PropertyDefin
 		}
 
 		return doubleArrayPropertyParser;
+	}
+
+	@Override
+	public boolean isValid(final ErrorBuffer errorBuffer) {
+
+		boolean valid = super.isValid(errorBuffer);
+
+		valid &= ValidationHelper.isValidStringMatchingRegex(this, name, schemaPropertyNamePattern, errorBuffer);
+
+		return valid;
 	}
 
 	@Override

--- a/structr-core/src/main/java/org/structr/core/entity/SchemaRelationshipNode.java
+++ b/structr-core/src/main/java/org/structr/core/entity/SchemaRelationshipNode.java
@@ -41,6 +41,8 @@ import org.slf4j.LoggerFactory;
 import org.structr.api.Predicate;
 import org.structr.api.graph.PropagationDirection;
 import org.structr.api.graph.PropagationMode;
+import org.structr.api.schema.JsonSchema;
+import org.structr.api.schema.JsonSchema.Cascade;
 import org.structr.api.util.Iterables;
 import org.structr.common.CaseHelper;
 import org.structr.common.PermissionPropagation;
@@ -75,8 +77,6 @@ import org.structr.schema.SchemaHelper.Type;
 import org.structr.schema.SourceFile;
 import org.structr.schema.SourceLine;
 import org.structr.schema.action.ActionEntry;
-import org.structr.api.schema.JsonSchema;
-import org.structr.api.schema.JsonSchema.Cascade;
 import org.structr.schema.parser.Validator;
 
 /**
@@ -84,6 +84,8 @@ import org.structr.schema.parser.Validator;
  *
  */
 public class SchemaRelationshipNode extends AbstractSchemaNode {
+
+	public static final String schemaRemoteAttributeNamePattern    = "[a-zA-Z_][a-zA-Z0-9_]*";
 
 	private static final Logger logger                              = LoggerFactory.getLogger(SchemaRelationshipNode.class.getName());
 	private static final Set<Class> propagatingRelTypes             = new HashSet<>();
@@ -172,6 +174,8 @@ public class SchemaRelationshipNode extends AbstractSchemaNode {
 
 		boolean valid = super.isValid(errorBuffer);
 
+		valid &= ValidationHelper.isValidStringMatchingRegex(this, sourceJsonName, schemaRemoteAttributeNamePattern, errorBuffer);
+		valid &= ValidationHelper.isValidStringMatchingRegex(this, targetJsonName, schemaRemoteAttributeNamePattern, errorBuffer);
 		valid &= ValidationHelper.isValidStringNotBlank(this, relationshipType, errorBuffer);
 		valid &= ValidationHelper.isValidPropertyNotNull(this, sourceNode, errorBuffer);
 		valid &= ValidationHelper.isValidPropertyNotNull(this, targetNode, errorBuffer);

--- a/structr-core/src/main/java/org/structr/core/entity/SchemaView.java
+++ b/structr-core/src/main/java/org/structr/core/entity/SchemaView.java
@@ -19,7 +19,9 @@
 package org.structr.core.entity;
 
 import org.structr.common.PropertyView;
+import org.structr.common.ValidationHelper;
 import org.structr.common.View;
+import org.structr.common.error.ErrorBuffer;
 import org.structr.core.entity.relationship.SchemaNodeView;
 import org.structr.core.entity.relationship.SchemaViewProperty;
 import org.structr.core.graph.ModificationQueue;
@@ -36,6 +38,8 @@ import org.structr.core.property.StringProperty;
  *
  */
 public class SchemaView extends SchemaReloadingNode {
+
+	public static final String schemaViewNamePattern    = "[a-zA-Z_][a-zA-Z0-9_]*";
 
 	public static final Property<AbstractSchemaNode>   schemaNode           = new StartNode<>("schemaNode", SchemaNodeView.class, new PropertySetNotion(AbstractNode.id, AbstractNode.name));
 	public static final Property<Iterable<SchemaProperty>> schemaProperties = new EndNodes<>("schemaProperties", SchemaViewProperty.class, new PropertySetNotion(AbstractNode.id, AbstractNode.name, SchemaProperty.isBuiltinProperty));
@@ -58,6 +62,16 @@ public class SchemaView extends SchemaReloadingNode {
 	public static final View exportView = new View(SchemaView.class, "export",
 		id, type, name, schemaNode, nonGraphProperties, isBuiltinView, sortOrder
 	);
+
+	@Override
+	public boolean isValid(final ErrorBuffer errorBuffer) {
+
+		boolean valid = super.isValid(errorBuffer);
+
+		valid &= ValidationHelper.isValidStringMatchingRegex(this, name, schemaViewNamePattern, errorBuffer);
+
+		return valid;
+	}
 
 	@Override
 	public boolean reloadSchemaOnCreate() {

--- a/structr-ui/src/main/resources/structr/js/schema.js
+++ b/structr-ui/src/main/resources/structr/js/schema.js
@@ -1517,7 +1517,7 @@ var _Schema = {
 						}
 					}
 				}, function(data) {
-					Structr.errorFromResponse(data.responseJSON);
+					Structr.errorFromResponse(data.responseJSON, undefined, {requiresConfirmation: true});
 					blinkRed(tr);
 				});
 			});
@@ -1764,7 +1764,7 @@ var _Schema = {
 				}
 			},
 			function(data) {
-				Structr.errorFromResponse(data.responseJSON);
+				Structr.errorFromResponse(data.responseJSON, undefined, {requiresConfirmation: true});
 				blinkRed(tr);
 			});
 		} else {
@@ -2349,7 +2349,7 @@ var _Schema = {
 				updateAttributeName(true);
 			}, function(data) {
 				blinkRed(row);
-				Structr.errorFromResponse(data.responseJSON);
+				Structr.errorFromResponse(data.responseJSON, undefined, {requiresConfirmation: true});
 			}, function () {
 				updateAttributeName(false);
 			});
@@ -2371,7 +2371,7 @@ var _Schema = {
 					blinkGreen(row);
 				}, function(data) {
 					blinkRed(row);
-					Structr.errorFromResponse(data.responseJSON);
+					Structr.errorFromResponse(data.responseJSON, undefined, {requiresConfirmation: true});
 				});
 			}
 		});
@@ -2784,6 +2784,7 @@ var _Schema = {
 							onNoChange();
 						}
 						_Schema.reload();
+						_Schema.hideSchemaRecompileMessage();
 					}
 				}
 			}


### PR DESCRIPTION
… views and remote attributes

For remote attributes and properties a GraphQL error message would prevent any other names (but not make it to the UI).
For methods and views the compilation process prevents any other names (but takes a bit longer than checking it)