### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka-clients to 3.4.0

### DIFF
--- a/structr-modules/structr-messaging-engine-module/pom.xml
+++ b/structr-modules/structr-messaging-engine-module/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.2.0</version>
+			<version>3.4.0</version>
 		</dependency>
 
 		<!-- Pulsar -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka-clients 3.2.0
- [CVE-2023-25194](https://www.oscs1024.com/hd/CVE-2023-25194)


### What did I do？
Upgrade org.apache.kafka:kafka-clients from 3.2.0 to 3.4.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS