### PR TITLE
Feature: Adds context information to NotEmpty error messages about...

### DIFF
--- a/structr-base/src/main/java/org/structr/common/helper/ValidationHelper.java
+++ b/structr-base/src/main/java/org/structr/common/helper/ValidationHelper.java
@@ -29,6 +29,7 @@ import org.structr.core.app.StructrApp;
 import org.structr.core.entity.AbstractNode;
 import org.structr.core.graph.NodeInterface;
 import org.structr.core.graph.RelationshipInterface;
+import org.structr.core.graph.TransactionCommand;
 import org.structr.core.property.PropertyKey;
 import org.structr.core.property.PropertyMap;
 
@@ -135,11 +136,17 @@ public class ValidationHelper {
 			} else {
 
 				return true;
-
 			}
 		}
 
-		errorBuffer.add(new EmptyPropertyToken(type, key.jsonName()));
+		final EmptyPropertyToken ept = new EmptyPropertyToken(type, key.jsonName());
+
+		// for nodes, that were not created in the current tx, add the detail UUID
+		if (!TransactionCommand.getCurrentTransaction().isNodeCreated(node.getPropertyContainer().getId().getId())) {
+			ept.withDetail(node.getUuid());
+		}
+
+		errorBuffer.add(ept);
 
 		return false;
 	}

--- a/structr-base/src/main/java/org/structr/core/graph/DeleteNodeCommand.java
+++ b/structr-base/src/main/java/org/structr/core/graph/DeleteNodeCommand.java
@@ -54,7 +54,7 @@ public class DeleteNodeCommand extends NodeServiceCommand {
 	private void cascadeDelete(final NodeInterface node) throws FrameworkException {
 
 		final DeleteRelationshipCommand drc           = StructrApp.getInstance().command(DeleteRelationshipCommand.class);
-		final PrincipalInterface user                          = securityContext.getCachedUser();
+		final PrincipalInterface user                 = securityContext.getCachedUser();
 		final Set<RelationshipInterface> relsToDelete = new HashSet<>();
 		final Set<NodeInterface> nodesToDelete        = new HashSet<>();
 		final Set<NodeInterface> nodesToCheck         = new HashSet<>();

--- a/structr-base/src/main/java/org/structr/core/graph/TransactionCommand.java
+++ b/structr-base/src/main/java/org/structr/core/graph/TransactionCommand.java
@@ -283,6 +283,8 @@ public class TransactionCommand {
 
 			assertSameTransaction(node, command.getTransactionId());
 
+			TransactionCommand.getCurrentTransaction().setNodeIsCreated(node.getNode().getId().getId());
+
 			ModificationQueue modificationQueue = command.getModificationQueue();
 			if (modificationQueue != null) {
 

--- a/structr-base/src/main/java/org/structr/core/graph/TransactionReference.java
+++ b/structr-base/src/main/java/org/structr/core/graph/TransactionReference.java
@@ -47,6 +47,16 @@ public class TransactionReference implements Transaction {
 	}
 
 	@Override
+	public void setNodeIsCreated(final long id) {
+		tx.setNodeIsCreated(id);
+	}
+
+	@Override
+	public boolean isNodeCreated(final long id) {
+		return tx.isNodeCreated(id);
+	}
+
+	@Override
 	public boolean isNodeDeleted(final long id) {
 		return tx.isNodeDeleted(id);
 	}

--- a/structr-db-driver-api/src/main/java/org/structr/api/Transaction.java
+++ b/structr-db-driver-api/src/main/java/org/structr/api/Transaction.java
@@ -31,6 +31,8 @@ public interface Transaction extends AutoCloseable, Prefetcher {
 	void success();
 	long getTransactionId();
 	boolean isSuccessful();
+	void setNodeIsCreated(final long id);
+	boolean isNodeCreated(final long id);
 	boolean isNodeDeleted(final long id);
 	boolean isRelationshipDeleted(final long id);
 

--- a/structr-memory-driver/src/main/java/org/structr/memory/MemoryTransaction.java
+++ b/structr-memory-driver/src/main/java/org/structr/memory/MemoryTransaction.java
@@ -43,6 +43,7 @@ public class MemoryTransaction implements Transaction {
 	//private final Map<MemoryIdentity, MemoryNode> createdNodes                 = new LinkedHashMap<>();
 	private final Set<MemoryEntity> modifiedEntities                           = new LinkedHashSet<>();
 	private final Set<MemoryIdentity> deletedNodes                             = new LinkedHashSet<>();
+	private final Set<Long> nodesCreated                                       = new LinkedHashSet<>();
 	private final long transactionId                                           = idCounter.incrementAndGet();
 	private MemoryDatabaseService db                                           = null;
 	private boolean failureOverride                                            = false;
@@ -118,12 +119,24 @@ public class MemoryTransaction implements Transaction {
 	}
 
 	@Override
+	public void setNodeIsCreated(final long id) {
+		nodesCreated.add(id);
+	}
+
+	@Override
+	public boolean isNodeCreated(final long id) {
+		return nodesCreated.contains(id);
+	}
+
+	@Override
 	public boolean isNodeDeleted(final long id) {
 		return deletedNodes.contains(id);
 	}
 
 	public void create(final MemoryNode newNode) {
 		createdNodes.add(newNode);
+
+		setNodeIsCreated(newNode.getIdentity().getId());
 	}
 
 	public void create(final MemoryRelationship newRelationship) {

--- a/structr-neo4j-bolt-driver/src/main/java/org/structr/bolt/SessionTransaction.java
+++ b/structr-neo4j-bolt-driver/src/main/java/org/structr/bolt/SessionTransaction.java
@@ -56,6 +56,7 @@ abstract class SessionTransaction implements org.structr.api.Transaction {
 	protected final Map<Long, RelationshipWrapper> rels = new LinkedHashMap<>();
 	protected final Map<Long, NodeWrapper> nodes        = new LinkedHashMap<>();
 	protected final Set<Long> deletedNodes              = new LinkedHashSet<>();
+	protected final Set<Long> createdNodes              = new LinkedHashSet<>();
 	protected final Set<Long> deletedRels               = new LinkedHashSet<>();
 	protected final Set<String> prefetchedOutgoing      = new LinkedHashSet<>();
 	protected final Set<String> prefetchedIncoming      = new LinkedHashSet<>();
@@ -233,6 +234,16 @@ abstract class SessionTransaction implements org.structr.api.Transaction {
 	@Override
 	public org.structr.api.graph.Relationship getRelationship(Identity id) {
 		return getRelationshipWrapper(id.getId());
+	}
+
+	@Override
+	public void setNodeIsCreated(final long id) {
+		createdNodes.add(id);
+	}
+
+	@Override
+	public boolean isNodeCreated(final long id) {
+		return createdNodes.contains(id);
 	}
 
 	@Override


### PR DESCRIPTION
...the node that caused the transaction to be rolled back (only if the node was not just created, because in that case, its UUID would be useless because the node does not exist after the rollback)