### PR TITLE
Fix insecure encryption mode in CryptFunction.java

### DIFF
--- a/structr-base/src/main/java/org/structr/core/function/CryptFunction.java
+++ b/structr-base/src/main/java/org/structr/core/function/CryptFunction.java
@@ -33,7 +33,7 @@ public abstract class CryptFunction extends AdvancedScriptingFunction {
 	public static byte[] secretKeyHash    = null;
 	public static final String CHARSET    = "UTF-8";
 	public static final String HASH_ALGO  = "MD5";
-	public static final String CRYPT_ALGO = "AES";
+	public static final String CRYPT_ALGO = "AES/CFB/PKCS5Padding";
 
 	// ----- public static methods -----
 	public static void setEncryptionKey(final String key) {


### PR DESCRIPTION
### Description:
I found that CryptFunction uses plain "AES" which defaults to ECB mode. This mode is known to be insecure since it can reveal patterns in encrypted data. My fix changes it to explicitly use "AES/CFB/PKCS5Padding" instead, which is much more secure while requiring just a one-line change.


### Reference:
[CWE-327](https://cwe.mitre.org/data/definitions/327.html)